### PR TITLE
use `_MEDIA_PLAYER_SCHEMA` instead of `MEDIA_PLAYER_SCHEMA` 

### DIFF
--- a/my_components/singlecore_i2s_audio/i2s_audio_media_player.cpp
+++ b/my_components/singlecore_i2s_audio/i2s_audio_media_player.cpp
@@ -1,8 +1,5 @@
 #include "i2s_audio_media_player.h"
 
-// #define LED1_Pin            12        // external LED1 pin
-// #define LED2_Pin            13        // external LED2 pin
-
 namespace esphome {
 namespace i2s_audio {
 
@@ -123,7 +120,7 @@ void I2SAudioMediaPlayer::stopPlaying() {
     broadcastStatus("idle");
     this->state = media_player::MEDIA_PLAYER_STATE_IDLE;
     this->publish_state();
-    updateLEDBrightness(0);
+    //updateLEDBrightness(0);
     ESP_LOGCONFIG(TAG, "Stoped and Idle");
 }
 
@@ -136,7 +133,7 @@ void I2SAudioMediaPlayer::playaudio(const char* source)  {
     file_http = new AudioFileSourceHTTPStream();
     if ( file_http->open(source)) {
         broadcastStatus("playing");
-        updateLEDBrightness(10);
+        //updateLEDBrightness(10);
         ESP_LOGCONFIG(TAG, "url:");
         ESP_LOGCONFIG(TAG, source);
         // dim while playing
@@ -154,7 +151,7 @@ void I2SAudioMediaPlayer::setup() {
 
   // pinMode(LED1_Pin, OUTPUT); 
   // pinMode(LED2_Pin, OUTPUT);
-  updateLEDBrightness(0);
+  //updateLEDBrightness(0);
 
   out = new AudioOutputI2S();
   if(mclk_pin_ == 250) {

--- a/my_components/singlecore_i2s_audio/media_player.py
+++ b/my_components/singlecore_i2s_audio/media_player.py
@@ -55,7 +55,7 @@ CONFIG_SCHEMA = cv.All(
                     cv.Required(CONF_MODE): cv.enum(INTERNAL_DAC_OPTIONS, lower=True),
                 }
             )
-            .extend(media_player.MEDIA_PLAYER_SCHEMA)
+            .extend(media_player._MEDIA_PLAYER_SCHEMA)
             .extend(cv.COMPONENT_SCHEMA),
             "external": cv.Schema(
                 {
@@ -78,7 +78,7 @@ CONFIG_SCHEMA = cv.All(
                     ),
                 }
             )
-            .extend(media_player.MEDIA_PLAYER_SCHEMA)
+            .extend(media_player._MEDIA_PLAYER_SCHEMA)
             .extend(cv.COMPONENT_SCHEMA),
         },
         key=CONF_DAC_TYPE,


### PR DESCRIPTION
fixes #3 (due to update in ESPHome in https://github.com/esphome/esphome/pull/8784)

and remove calls to updateLEDBrightness as no LED is being used.